### PR TITLE
Fix/wakeword false positive

### DIFF
--- a/client/mic_service.py
+++ b/client/mic_service.py
@@ -9,6 +9,7 @@ VAD_CHUNK = 320 # 320 samples (20ms at 16kHz)
 NO_SPEECH_TIMEOUT = 5.0 # Seconds with no speech detected before returning to IDLE
 POST_SPEECH_SILENCE = 1.0 # Seconds of silence after speech before treating utterance as complete
 WAKEWORD_THRESHOLD = 0.7 # openWakeWord detection threshold
+WAKEWORD_COOLDOWN = 6.0
 VAD_AGGRESSIVENESS = 2
 
 def detect_wakeword(model: Model, data: bytes) -> bool:
@@ -38,6 +39,9 @@ def post_speech_timeout_passed(now, last_speech_at, post_speech_silence):
 
 def listening_state_timeout_passed(now, listening_entered_at, no_speech_timeout):
     return now - listening_entered_at > no_speech_timeout
+
+def wakeword_cooldown_passed(now, last_wakeword_time, wakeword_cooldown):
+    return now - last_wakeword_time > wakeword_cooldown
 
 def thread_shutdown(stream, audio):
     stream.stop_stream()
@@ -90,7 +94,7 @@ def mic_loop(brain, shutdown_event, startup_barrier, audio_queue, playback_queue
         if current_state == JarvisState.IDLE:
             data = stream.read(OWW_CHUNK, exception_on_overflow=False)
             now = time.time()
-            if detect_wakeword(oww_model, data) and now - last_wakeword_time > NO_SPEECH_TIMEOUT:
+            if detect_wakeword(oww_model, data) and wakeword_cooldown_passed(now, last_wakeword_time, WAKEWORD_COOLDOWN):
                 last_wakeword_time = now
                 oww_model.reset()
                 play_wakeword_feedback(playback_queue, beep_bytes)

--- a/client/mic_service.py
+++ b/client/mic_service.py
@@ -8,7 +8,7 @@ OWW_CHUNK = 1280 # 1280 samples (80ms at 16kHz)
 VAD_CHUNK = 320 # 320 samples (20ms at 16kHz)
 NO_SPEECH_TIMEOUT = 5.0 # Seconds with no speech detected before returning to IDLE
 POST_SPEECH_SILENCE = 1.0 # Seconds of silence after speech before treating utterance as complete
-WAKEWORD_THRESHOLD = 0.5 # openWakeWord detection threshold
+WAKEWORD_THRESHOLD = 0.7 # openWakeWord detection threshold
 VAD_AGGRESSIVENESS = 2
 
 def detect_wakeword(model: Model, data: bytes) -> bool:

--- a/client/mic_service.py
+++ b/client/mic_service.py
@@ -90,7 +90,7 @@ def mic_loop(brain, shutdown_event, startup_barrier, audio_queue, playback_queue
         if current_state == JarvisState.IDLE:
             data = stream.read(OWW_CHUNK, exception_on_overflow=False)
             now = time.time()
-            if detect_wakeword(oww_model, data) and now - last_wakeword_time > 2.0:
+            if detect_wakeword(oww_model, data) and now - last_wakeword_time > NO_SPEECH_TIMEOUT:
                 last_wakeword_time = now
                 oww_model.reset()
                 play_wakeword_feedback(playback_queue, beep_bytes)

--- a/client/mic_service.py
+++ b/client/mic_service.py
@@ -9,7 +9,7 @@ VAD_CHUNK = 320 # 320 samples (20ms at 16kHz)
 NO_SPEECH_TIMEOUT = 5.0 # Seconds with no speech detected before returning to IDLE
 POST_SPEECH_SILENCE = 1.0 # Seconds of silence after speech before treating utterance as complete
 WAKEWORD_THRESHOLD = 0.7 # openWakeWord detection threshold
-WAKEWORD_COOLDOWN = 6.0
+WAKEWORD_COOLDOWN = 7.0
 VAD_AGGRESSIVENESS = 2
 
 def detect_wakeword(model: Model, data: bytes) -> bool:


### PR DESCRIPTION
- change the openwakeword wakeword detection model threshold from 0.5 to 0.7 to prevent false positives
- add wakeword cooldown constant `WAKEWORD_COOLDOWN=6.0` and a new function `wakeword_cooldown_passed` to implement wakeword cooldown logic.